### PR TITLE
Sort living options by total cost on calculate

### DIFF
--- a/src/london-cost-calculator.tsx
+++ b/src/london-cost-calculator.tsx
@@ -300,7 +300,7 @@ function LondonCostCalculator() {
 
   const calculateCosts = () => {
     if (!workLocation) return;
-    
+
     const calculatedResults = Object.entries(locationData).map(([location, data]) => {
       const rent = data.rent[bedrooms];
       const councilTaxYearly = data.councilTaxYearly[bedrooms];
@@ -321,8 +321,9 @@ function LondonCostCalculator() {
         bedrooms: bedrooms
       };
     });
-    
-    setResults(calculatedResults);
+    const sortedResults = [...calculatedResults].sort((a, b) => a.totalMonthly - b.totalMonthly);
+    setSortBy('total');
+    setResults(sortedResults);
   };
 
   const sortResults = (criteria) => {


### PR DESCRIPTION
## Summary
- sort results by total cost when calculating living options

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies and type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684e1169d71483228fc30552e00c68e5