### PR TITLE
Fix BedroomCount import

### DIFF
--- a/src/london-cost-calculator.tsx
+++ b/src/london-cost-calculator.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 
 import { commuteTimes } from "./commute-times";
-import { locationData, BedroomCount } from "./location-data";
+import { locationData, type BedroomCount } from "./location-data";
 import { Train, Building2, Home } from 'lucide-react';
 
 


### PR DESCRIPTION
## Summary
- use type-only import for `BedroomCount` in London cost calculator
- add a trailing newline

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855ef546cec8322aeab7837a1467c08