### PR TITLE
Fix workflows and vercel preview

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,9 +9,7 @@ on:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.actor == 'github-actions[bot]'
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Enable Auto-merge
         uses: peter-evans/enable-pull-request-automerge@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+        env:
+          GITHUB_PAGES: true
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-    base: '/Where-to-live-in-London-v3/',
+  base: process.env.GITHUB_PAGES ? '/Where-to-live-in-London-v3/' : '/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- fix automerge job condition so it runs after CI workflow completes
- allow Vite base path switching for Vercel preview vs GitHub Pages
- set GITHUB_PAGES env var when building during deploy

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685736ccf5d483228925ba414bb6f3eb